### PR TITLE
[setup.py] prompt_toolkit depency requires version 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "logbook",
         "peewee",
         "janus",
-        "prompt_toolkit",
+        "prompt_toolkit>2<3",
         "typing;python_version<'3.5'",
         "matrix-nio[e2e] >= 0.4.1"
     ],


### PR DESCRIPTION
Fixes #34 and #32 