### PR TITLE
Do not try to login if the user authenticated via other means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.X.X XXXX-XX-XX
+
+### Changed
+
+- [[#69]] If no password is provided to /login, the daemon will re-use the original login response.
+
+[#69]: https://github.com/matrix-org/pantalaimon/pull/69
+
 ## 0.7.0 2020-09-02
 
 ### Fixed

--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -581,7 +581,10 @@ class ProxyDaemon:
 
         if password == "":
             if device_id is None:
-                logger.warn(f"Empty password provided and device_id was also None")
+                logger.warn(
+                    "Empty password provided and device_id was also None, not "
+                    "starting background sync client "
+                )
                 return
             # If password is blank, we cannot login normally and must
             # fall back to using the provided device_id.

--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -581,7 +581,8 @@ class ProxyDaemon:
 
         if password == "":
             if device_id is None:
-                raise ValueError("Empty password provided, but device_id was also None")
+                logger.warn(f"Empty password provided and device_id was also None")
+                return
             # If password is blank, we cannot login normally and must
             # fall back to using the provided device_id.
             pan_client.restore_login(user_id, device_id, access_token)

--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -580,6 +580,8 @@ class ProxyDaemon:
         )
 
         if password == "":
+            if device_id is None:
+                raise ValueError("Empty password provided, but device_id was also None")
             # If password is blank, we cannot login normally and must
             # fall back to using the provided device_id.
             pan_client.restore_login(user_id, device_id, access_token)


### PR DESCRIPTION
The plan for encrypted bridges is for them to authenticate using access tokens rather than a password, which means that when Pan attempts to login with a provided password, it falls over. I'm not terribly happy with this solution, but it's does make things work again.