### PR TITLE
Use correct homeserver URL in example description

### DIFF
--- a/docs/man/pantalaimon.5
+++ b/docs/man/pantalaimon.5
@@ -128,7 +128,7 @@ Default location of the configuration file.
 The following example shows a configured pantalaimon proxy with the name
 .Em Clocktown ,
 the homeserver URL is set to
-.Em https://example.org ,
+.Em https://localhost:8448 ,
 the pantalaimon proxy is listening for client connections on the address
 .Em localhost ,
 and port

--- a/docs/man/pantalaimon.5.md
+++ b/docs/man/pantalaimon.5.md
@@ -111,7 +111,7 @@ overridden using appropriate environment variables.
 The following example shows a configured pantalaimon proxy with the name
 *Clocktown*,
 the homeserver URL is set to
-*https://example.org*,
+*https://localhost:8448*,
 the pantalaimon proxy is listening for client connections on the address
 *localhost*,
 and port


### PR DESCRIPTION
The homeserver URL used in the description did not match the one in the example config