### PR TITLE
setup.py: Bump the allowed nio version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "cachetools >= 3.0.0",
         "prompt_toolkit > 2, < 4",
         "typing;python_version<'3.5'",
-        "matrix-nio[e2e] >= 0.14, < 0.17"
+        "matrix-nio[e2e] >= 0.14, < 0.18"
     ],
     extras_require={
         "ui": [


### PR DESCRIPTION
According to the [changelog](https://github.com/poljar/matrix-nio/blob/0.17.0/CHANGELOG.md#0170---2021-03-01), there are no breaking changes.