### PR TITLE
Encrypt thumbnails uploaded by a client.

### DIFF
--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -953,21 +953,21 @@ class ProxyDaemon:
                             body=await response.transport_response.read(),
                         )
 
-                    media_content = media_info.to_content(content, upload_info.mimetype)
-                    if media_content["info"].get("thumbnail_url", False):
+                    media_info.to_content(content, upload_info.mimetype)
+                    if content["info"].get("thumbnail_url", False):
                         (
                             thumb_upload_info,
                             thumb_media_info,
                         ) = self._get_upload_and_media_info(
-                            "thumbnail_url", media_content["info"]
+                            "thumbnail_url", content["info"]
                         )
                         if thumb_upload_info and thumb_media_info:
-                            media_content = thumb_media_info.to_thumbnail(
-                                media_content, thumb_upload_info.mimetype
+                            thumb_media_info.to_thumbnail(
+                                content, thumb_upload_info.mimetype
                             )
 
                     response = await client.room_send(
-                        room_id, msgtype, media_content, txnid, ignore_unverified
+                        room_id, msgtype, content, txnid, ignore_unverified
                     )
                 else:
                     response = await client.room_send(

--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -954,6 +954,17 @@ class ProxyDaemon:
                         )
 
                     media_content = media_info.to_content(content, upload_info.mimetype)
+                    if media_content["info"].get("thumbnail_url", False):
+                        (
+                            thumb_upload_info,
+                            thumb_media_info,
+                        ) = self._get_upload_and_media_info(
+                            "thumbnail_url", media_content["info"]
+                        )
+                        if thumb_upload_info and thumb_media_info:
+                            media_content = thumb_media_info.to_thumbnail(
+                                media_content, thumb_upload_info.mimetype
+                            )
 
                     response = await client.room_send(
                         room_id, msgtype, media_content, txnid, ignore_unverified

--- a/pantalaimon/store.py
+++ b/pantalaimon/store.py
@@ -60,6 +60,19 @@ class MediaInfo:
 
         return content
 
+    def to_thumbnail(self, content: Dict, mime_type: str) -> Dict[Any, Any]:
+        content["info"]["thumbnail_file"] = {
+            "v": "v2",
+            "key": self.key,
+            "iv": self.iv,
+            "hashes": self.hashes,
+            "url": content["info"]["thumbnail_url"],
+            "mimetype": mime_type,
+        }
+
+        return content
+
+
 
 @attr.s
 class UploadInfo:

--- a/pantalaimon/store.py
+++ b/pantalaimon/store.py
@@ -58,7 +58,6 @@ class MediaInfo:
                 "mimetype": mime_type,
         }
 
-        return content
 
     def to_thumbnail(self, content: Dict, mime_type: str) -> Dict[Any, Any]:
         content["info"]["thumbnail_file"] = {
@@ -69,9 +68,6 @@ class MediaInfo:
             "url": content["info"]["thumbnail_url"],
             "mimetype": mime_type,
         }
-
-        return content
-
 
 
 @attr.s

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "cachetools >= 3.0.0",
         "prompt_toolkit > 2, < 4",
         "typing;python_version<'3.5'",
-        "matrix-nio[e2e] >= 0.14, < 0.18"
+        "matrix-nio[e2e] >= 0.14, < 0.19"
     ],
     extras_require={
         "ui": [


### PR DESCRIPTION
If a client supplies a thumbnail when sending some media into a room, pantalaimon does not currently add the information to decrypt the thumbnail to the outgoing message - meaning that the thumbnail is not displayed.

This fixes that problem by adding the thumbnail_file key in the same way that the file key is added to the outgoing message.

I wasn't sure of the most sensible way to do this (I'm not very familiar with pantalaimon's codebase), but the method I've used seems to work for me! However it's quite possible I've missed or misunderstood something.