### PR TITLE
pantalaimon: Forward raw path instead of quoting the decoded path

### DIFF
--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -482,9 +482,7 @@ class ProxyDaemon:
 
         assert session
 
-        path = urllib.parse.quote(
-            request.path
-        )  # re-encode path stuff like room aliases
+        path = request.raw_path
         method = request.method
 
         headers = CIMultiDict(request.headers)


### PR DESCRIPTION
If the original path had quoted slash characters (`%2F`), the code
decoded them and then left them unquoted, causing the forwarded request
to fail.

An example is trying to ban a user with a slash in their name using
Mjolnir, which PUTs a state event with `rule:<username>` in the URL.

Use the undecoded path to avoid this.