### PR TITLE
thumbnail_url can be None

### DIFF
--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -948,7 +948,10 @@ class ProxyDaemon:
             ):
                 try:
                     content["url"] = await self._decrypt_uri(content["url"], client)
-                    if "info" in content and "thumbnail_url" in content["info"]:
+                    if (
+                        "info" in content and "thumbnail_url" in content["info"]
+                        and not content["info"]["thumbnail_url"] == None
+                    ):
                         content["info"]["thumbnail_url"] = await self._decrypt_uri(
                             content["info"]["thumbnail_url"], client
                         )


### PR DESCRIPTION
thumbnail_url can be None

when finally passed down to `_get_upload_and_media_info`, https://github.com/matrix-org/pantalaimon/blob/master/pantalaimon/daemon.py#L847 will raiase a `TypeError` since in this case `urlparse` returns `netloc` as bytes instead of string