### PR TITLE
clarify wording in README#Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ IgnoreVerification = True
 Usage
 =====
 
-While pantalaimon is a daemon, it is meant to be run as your own user. It won't
+While pantalaimon is a daemon, it is meant to be run as the same user as the app it is proxying for. It won't
 verify devices for you automatically, unless configured to do so, and requires
 user interaction to verify, ignore or blacklist devices. A more complete
 description of Pantalaimon can be found in the [man page](docs/man/pantalaimon.8.md).


### PR DESCRIPTION
This came up in #matrix-admins-edu-german:matrix.org recently.

1. It is not entirely clear which "user" is meant here, it might mean the matrix user or OS user, both of which are correct but I believe the emphasis here is supposed to be on the OS user. I am not sure how to improve wording in that regard.
2. "Your own user" was interpreted as "its own user", i.e. having a system user for all pantalaimon instances. I believe that is specifically what is **not** intended here. Rather pantalaimon is supposed to be run the same as the app it is proxing, e.g. if using mjolnir, then pantalaimon should also be run by the mjolnir user; if run with element, then it should also be run from that same personal account. I hope that part is more clear with this PR.