### PR TITLE
readme: document required Debian packages for pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ provide a package building from source is required. Please refer to the Olm
 [readme](https://gitlab.matrix.org/matrix-org/olm/blob/master/README.md)
 to see how to build the C library from source.
 
+On Debian 11, use the following to satisfy dependencies:
+
+    # For the 'pantalaimon' pip:
+    sudo apt-get install libolm3 libolm-dev
+    # For the 'pantalaimon[ui]' pip:
+    sudo apt-get install pkg-config libcairo2-dev python3-dev python3-gi python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libdbus-1-dev
+
 Installing pantalaimon works like usually with python packages:
 
     python setup.py install


### PR DESCRIPTION
This PR adds a short paragraph in the README documenting the required library packages on Debian 11.

I had to reiterate the pip install a couple of times and hunt down the requirements before either package installed successfully. Hopefully this will spare the effort for others.
