### PR TITLE
Run pytest with asyncio mode set to auto

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
My understanding is that currently all of the coroutine functions decorated with `@pytest.fixture` are being skipped because pytest-asyncio is running in strict mode (https://pytest-asyncio.readthedocs.io/en/latest/concepts.html#test-discovery-modes). To fix this, you can either change all those declarations to `@pytest_asyncio.fixture` or add this config file, so I went with the least invasive change to a project I'm unfamiliar with.