### PR TITLE
chore: Remove depreciated dependency pydbus for dasbus

### DIFF
--- a/pantalaimon/panctl.py
+++ b/pantalaimon/panctl.py
@@ -34,7 +34,7 @@ from prompt_toolkit import HTML, PromptSession, print_formatted_text
 from prompt_toolkit.completion import Completer, Completion, PathCompleter
 from prompt_toolkit.document import Document
 from prompt_toolkit.patch_stdout import patch_stdout
-from pydbus import SessionBus
+from dasbus.connection import SessionMessageBus
 
 PTK2 = ptk_version.startswith("2.")
 
@@ -404,8 +404,8 @@ class PanCtl:
     commands = list(command_help.keys())
 
     def __attrs_post_init__(self):
-        self.bus = SessionBus()
-        self.pan_bus = self.bus.get("org.pantalaimon1")
+        self.bus = SessionMessageBus()
+        self.pan_bus = self.bus.get_connection("org.pantalaimon1")
 
         self.ctl = self.pan_bus["org.pantalaimon1.control"]
         self.devices = self.pan_bus["org.pantalaimon1.devices"]

--- a/pantalaimon/ui.py
+++ b/pantalaimon/ui.py
@@ -17,7 +17,7 @@ from importlib import util
 UI_ENABLED = (
     util.find_spec("gi") is not None
     and util.find_spec("gi.repository") is not None
-    and util.find_spec("pydbus") is not None
+    and util.find_spec("dasbus") is not None
 )
 
 if UI_ENABLED:
@@ -28,8 +28,8 @@ if UI_ENABLED:
     import dbus
     import notify2
     from gi.repository import GLib
-    from pydbus import SessionBus
-    from pydbus.generic import signal
+    from dasbus import SessionMessageBus
+    from dasbus.signal import Signal
     from dbus.mainloop.glib import DBusGMainLoop
 
     from nio import RoomKeyRequest, RoomKeyRequestCancellation
@@ -123,8 +123,8 @@ if UI_ENABLED:
         </node>
         """
 
-        Response = signal()
-        UnverifiedDevices = signal()
+        Response = Signal()
+        UnverifiedDevices = Signal()
 
         def __init__(self, queue, server_list, id_counter):
             self.queue = queue
@@ -297,13 +297,13 @@ if UI_ENABLED:
         </node>
         """
 
-        VerificationInvite = signal()
-        VerificationCancel = signal()
-        VerificationString = signal()
-        VerificationDone = signal()
+        VerificationInvite = Signal()
+        VerificationCancel = Signal()
+        VerificationString = Signal()
+        VerificationDone = Signal()
 
-        KeyRequest = signal()
-        KeyRequestCancel = signal()
+        KeyRequest = Signal()
+        KeyRequestCancel = Signal()
 
         def __init__(self, queue, id_counter):
             self.device_list = dict()
@@ -466,8 +466,8 @@ if UI_ENABLED:
             self.control_if = Control(self.send_queue, self.server_list, id_counter)
             self.device_if = Devices(self.send_queue, id_counter)
 
-            self.bus = SessionBus()
-            self.bus.publish("org.pantalaimon1", self.control_if, self.device_if)
+            self.bus = SessionMessageBus()
+            self.bus.publish_object("org.pantalaimon1", self.control_if, self.device_if)
 
         def unverified_notification(self, message):
             notification = notify2.Notification(

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "ui": [
             "dbus-python >= 1.2, < 1.3",
             "PyGObject >= 3.36, < 3.39",
-            "pydbus >= 0.6, < 0.7",
+            "dasbus == 1.71",
             "notify2 >= 0.3, < 0.4",
         ]
     },


### PR DESCRIPTION
Closes #162 by getting rid of `pydbus` in favor of `dasbus`.