### PR TITLE
chore: Format with ruff and lint

### DIFF
--- a/pantalaimon/client.py
+++ b/pantalaimon/client.py
@@ -709,7 +709,6 @@ class PanClient(AsyncClient):
             for share in self.get_active_key_requests(
                 message.user_id, message.device_id
             ):
-
                 continued = True
 
                 if not self.continue_key_share(share):
@@ -811,8 +810,9 @@ class PanClient(AsyncClient):
 
         if not isinstance(event, MegolmEvent):
             logger.warn(
-                "Encrypted event is not a megolm event:"
-                "\n{}".format(pformat(event_dict))
+                "Encrypted event is not a megolm event:" "\n{}".format(
+                    pformat(event_dict)
+                )
             )
             return False
 
@@ -836,9 +836,9 @@ class PanClient(AsyncClient):
                 decrypted_event.source["content"]["url"] = decrypted_event.url
 
                 if decrypted_event.thumbnail_url:
-                    decrypted_event.source["content"]["info"][
-                        "thumbnail_url"
-                    ] = decrypted_event.thumbnail_url
+                    decrypted_event.source["content"]["info"]["thumbnail_url"] = (
+                        decrypted_event.thumbnail_url
+                    )
 
             event_dict.update(decrypted_event.source)
             event_dict["decrypted"] = True

--- a/pantalaimon/client.py
+++ b/pantalaimon/client.py
@@ -16,7 +16,6 @@ import asyncio
 import os
 from collections import defaultdict
 from pprint import pformat
-from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 from aiohttp.client_exceptions import ClientConnectionError

--- a/pantalaimon/config.py
+++ b/pantalaimon/config.py
@@ -186,7 +186,6 @@ class PanConfig:
 
         try:
             for section_name, section in config.items():
-
                 if section_name == "Default":
                     continue
 

--- a/pantalaimon/daemon.py
+++ b/pantalaimon/daemon.py
@@ -227,7 +227,8 @@ class ProxyDaemon:
 
         if ret:
             msg = (
-                f"Device {device.id} of user " f"{device.user_id} successfully verified."
+                f"Device {device.id} of user "
+                f"{device.user_id} successfully verified."
             )
             await client.send_update_device(device)
         else:
@@ -309,7 +310,6 @@ class ProxyDaemon:
                 DeviceUnblacklistMessage,
             ),
         ):
-
             device = client.device_store[message.user_id].get(message.device_id, None)
 
             if not device:
@@ -616,7 +616,9 @@ class ProxyDaemon:
                 await pan_client.close()
                 return
 
-        logger.info(f"Successfully started new background sync client for " f"{user_id}")
+        logger.info(
+            f"Successfully started new background sync client for " f"{user_id}"
+        )
 
         await self.send_ui_message(
             UpdateUsersMessage(self.name, user_id, pan_client.device_id)
@@ -733,7 +735,7 @@ class ProxyDaemon:
                     return decryption_method(body, ignore_failures=False)
                 except EncryptionError:
                     logger.info("Error decrypting sync, waiting for next pan " "sync")
-                    await client.synced.wait(),
+                    (await client.synced.wait(),)
                     logger.info("Pan synced, retrying decryption.")
 
         try:
@@ -1273,7 +1275,9 @@ class ProxyDaemon:
         client = next(iter(self.pan_clients.values()))
 
         try:
-            response = await client.download(server_name=server_name, media_id=media_id, filename=file_name)
+            response = await client.download(
+                server_name=server_name, media_id=media_id, filename=file_name
+            )
         except ClientConnectionError as e:
             raise e
 

--- a/pantalaimon/index.py
+++ b/pantalaimon/index.py
@@ -230,7 +230,6 @@ if False:
             )
 
             for message in query:
-
                 event = message.event
 
                 event_dict = {

--- a/pantalaimon/index.py
+++ b/pantalaimon/index.py
@@ -23,7 +23,6 @@ if False:
     import json
     import os
     from functools import partial
-    from typing import Any, Dict, List, Optional, Tuple
 
     import attr
     import tantivy

--- a/pantalaimon/main.py
+++ b/pantalaimon/main.py
@@ -15,7 +15,6 @@
 import asyncio
 import os
 import signal
-from typing import Optional
 
 import click
 import janus

--- a/pantalaimon/store.py
+++ b/pantalaimon/store.py
@@ -431,7 +431,6 @@ class PanStore:
             device_store = defaultdict(dict)
 
             for d in account.device_keys:
-
                 if d.deleted:
                     continue
 

--- a/pantalaimon/store.py
+++ b/pantalaimon/store.py
@@ -15,7 +15,7 @@
 import json
 import os
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict
 
 import attr
 from nio.crypto import TrustState, GroupSessionStore

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ setup(
     url="https://github.com/matrix-org/pantalaimon",
     author="The Matrix.org Team",
     author_email="poljar@termina.org.uk",
-    description=("A Matrix proxy daemon that adds E2E encryption "
-                 "capabilities."),
+    description=("A Matrix proxy daemon that adds E2E encryption " "capabilities."),
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="Apache License, Version 2.0",
@@ -29,7 +28,7 @@ setup(
         "cachetools >= 3.0.0",
         "prompt_toolkit > 2, < 4",
         "typing;python_version<'3.5'",
-        "matrix-nio[e2e] >= 0.20, < 0.21"
+        "matrix-nio[e2e] >= 0.20, < 0.21",
     ],
     extras_require={
         "ui": [
@@ -40,8 +39,10 @@ setup(
         ]
     },
     entry_points={
-        "console_scripts": ["pantalaimon=pantalaimon.main:main",
-                            "panctl=pantalaimon.panctl:main"],
+        "console_scripts": [
+            "pantalaimon=pantalaimon.main:main",
+            "panctl=pantalaimon.panctl:main",
+        ],
     },
-    zip_safe=False
+    zip_safe=False,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,11 +34,9 @@ class Provider(BaseProvider):
     def client(self):
         return ClientInfo(faker.mx_id(), faker.access_token())
 
-
     def avatar_url(self):
         return "mxc://{}/{}#auto".format(
-            faker.hostname(),
-            "".join(choices(ascii_letters) for i in range(24))
+            faker.hostname(), "".join(choices(ascii_letters) for i in range(24))
         )
 
     def olm_key_pair(self):
@@ -54,7 +52,6 @@ class Provider(BaseProvider):
             device_id,
             key_pair,
         )
-
 
 
 faker.add_provider(Provider)
@@ -80,13 +77,7 @@ def tempdir():
 @pytest.fixture
 def panstore(tempdir):
     for _ in range(10):
-        store = SqliteStore(
-            faker.mx_id(),
-            faker.device_id(),
-            tempdir,
-            "",
-            "pan.db"
-        )
+        store = SqliteStore(faker.mx_id(), faker.device_id(), tempdir, "", "pan.db")
         account = OlmAccount()
         store.save_account(account)
 
@@ -130,21 +121,23 @@ async def pan_proxy_server(tempdir, aiohttp_server):
         recv_queue=ui_queue.async_q,
         proxy=None,
         ssl=False,
-        client_store_class=SqliteStore
+        client_store_class=SqliteStore,
     )
 
-    app.add_routes([
-        web.post("/_matrix/client/r0/login", proxy.login),
-        web.get("/_matrix/client/r0/sync", proxy.sync),
-        web.get("/_matrix/client/r0/rooms/{room_id}/messages", proxy.messages),
-        web.put(
-            r"/_matrix/client/r0/rooms/{room_id}/send/{event_type}/{txnid}",
-            proxy.send_message
-        ),
-        web.post("/_matrix/client/r0/user/{user_id}/filter", proxy.filter),
-        web.post("/_matrix/client/r0/search", proxy.search),
-        web.options("/_matrix/client/r0/search", proxy.search_opts),
-    ])
+    app.add_routes(
+        [
+            web.post("/_matrix/client/r0/login", proxy.login),
+            web.get("/_matrix/client/r0/sync", proxy.sync),
+            web.get("/_matrix/client/r0/rooms/{room_id}/messages", proxy.messages),
+            web.put(
+                r"/_matrix/client/r0/rooms/{room_id}/send/{event_type}/{txnid}",
+                proxy.send_message,
+            ),
+            web.post("/_matrix/client/r0/user/{user_id}/filter", proxy.filter),
+            web.post("/_matrix/client/r0/search", proxy.search),
+            web.options("/_matrix/client/r0/search", proxy.search_opts),
+        ]
+    )
 
     server = await aiohttp_server(app)
 
@@ -161,7 +154,7 @@ async def running_proxy(pan_proxy_server, aioresponse, aiohttp_client):
         "access_token": "abc123",
         "device_id": "GHTYAJCE",
         "home_server": "example.org",
-        "user_id": "@example:example.org"
+        "user_id": "@example:example.org",
     }
 
     aioclient = await aiohttp_client(server)
@@ -170,7 +163,7 @@ async def running_proxy(pan_proxy_server, aioresponse, aiohttp_client):
         "https://example.org/_matrix/client/r0/login",
         status=200,
         payload=login_response,
-        repeat=True
+        repeat=True,
     )
 
     await aioclient.post(
@@ -179,7 +172,7 @@ async def running_proxy(pan_proxy_server, aioresponse, aiohttp_client):
             "type": "m.login.password",
             "user": "example",
             "password": "wordpass",
-        }
+        },
     )
 
     yield server, aioclient, proxy, queues

--- a/tests/pan_client_test.py
+++ b/tests/pan_client_test.py
@@ -380,7 +380,9 @@ class TestClass(object):
         )
 
         aioresponse.get(
-            sync_url, status=200, payload=self.initial_sync_response,
+            sync_url,
+            status=200,
+            payload=self.initial_sync_response,
         )
 
         aioresponse.get(sync_url, status=200, payload=self.empty_sync, repeat=True)
@@ -454,7 +456,9 @@ class TestClass(object):
         )
 
         aioresponse.get(
-            sync_url, status=200, payload=self.initial_sync_response,
+            sync_url,
+            status=200,
+            payload=self.initial_sync_response,
         )
 
         aioresponse.get(sync_url, status=200, payload=self.empty_sync, repeat=True)

--- a/tests/proxy_test.py
+++ b/tests/proxy_test.py
@@ -27,7 +27,7 @@ class TestClass(object):
             "access_token": "abc123",
             "device_id": "GHTYAJCE",
             "home_server": "example.org",
-            "user_id": "@example:example.org"
+            "user_id": "@example:example.org",
         }
 
     @property
@@ -36,12 +36,7 @@ class TestClass(object):
 
     @property
     def keys_upload_response(self):
-        return {
-            "one_time_key_counts": {
-                "curve25519": 10,
-                "signed_curve25519": 20
-            }
-        }
+        return {"one_time_key_counts": {"curve25519": 10, "signed_curve25519": 20}}
 
     @property
     def example_devices(self):
@@ -52,10 +47,7 @@ class TestClass(object):
             devices[device.user_id][device.id] = device
 
         bob_device = OlmDevice(
-            BOB_ID,
-            BOB_DEVICE,
-            {"ed25519": BOB_ONETIME,
-             "curve25519": BOB_CURVE}
+            BOB_ID, BOB_DEVICE, {"ed25519": BOB_ONETIME, "curve25519": BOB_CURVE}
         )
 
         devices[BOB_ID][BOB_DEVICE] = bob_device
@@ -71,7 +63,7 @@ class TestClass(object):
             "https://example.org/_matrix/client/r0/login",
             status=200,
             payload=self.login_response,
-            repeat=True
+            repeat=True,
         )
 
         assert not daemon.pan_clients
@@ -82,7 +74,7 @@ class TestClass(object):
                 "type": "m.login.password",
                 "user": "example",
                 "password": "wordpass",
-            }
+            },
         )
 
         assert resp.status == 200
@@ -105,11 +97,11 @@ class TestClass(object):
             "https://example.org/_matrix/client/r0/login",
             status=200,
             payload=self.login_response,
-            repeat=True
+            repeat=True,
         )
 
         sync_url = re.compile(
-            r'^https://example\.org/_matrix/client/r0/sync\?access_token=.*'
+            r"^https://example\.org/_matrix/client/r0/sync\?access_token=.*"
         )
 
         aioresponse.get(
@@ -124,14 +116,16 @@ class TestClass(object):
                 "type": "m.login.password",
                 "user": "example",
                 "password": "wordpass",
-            }
+            },
         )
 
         # Check that the pan client started to sync after logging in.
         pan_client = list(daemon.pan_clients.values())[0]
         assert len(pan_client.rooms) == 1
 
-    async def test_pan_client_keys_upload(self, pan_proxy_server, aiohttp_client, aioresponse):
+    async def test_pan_client_keys_upload(
+        self, pan_proxy_server, aiohttp_client, aioresponse
+    ):
         server, daemon, _ = pan_proxy_server
 
         client = await aiohttp_client(server)
@@ -140,11 +134,11 @@ class TestClass(object):
             "https://example.org/_matrix/client/r0/login",
             status=200,
             payload=self.login_response,
-            repeat=True
+            repeat=True,
         )
 
         sync_url = re.compile(
-            r'^https://example\.org/_matrix/client/r0/sync\?access_token=.*'
+            r"^https://example\.org/_matrix/client/r0/sync\?access_token=.*"
         )
 
         aioresponse.get(
@@ -169,7 +163,7 @@ class TestClass(object):
                 "type": "m.login.password",
                 "user": "example",
                 "password": "wordpass",
-            }
+            },
         )
 
         pan_client = list(daemon.pan_clients.values())[0]

--- a/tests/proxy_test.py
+++ b/tests/proxy_test.py
@@ -1,9 +1,7 @@
-import asyncio
 import json
 import re
 from collections import defaultdict
 
-from aiohttp import web
 from nio.crypto import OlmDevice
 
 from conftest import faker

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -1,12 +1,10 @@
 import asyncio
-import pdb
 import pprint
 import pytest
 
 from nio import RoomMessage, RoomEncryptedMedia
 
 from urllib.parse import urlparse
-from conftest import faker
 from pantalaimon.index import INDEXING_ENABLED
 from pantalaimon.store import FetchTask, MediaInfo, UploadInfo
 
@@ -81,7 +79,6 @@ class TestClass(object):
 
     def test_account_loading(self, panstore):
         accounts = panstore.load_all_users()
-        # pdb.set_trace()
         assert len(accounts) == 10
 
     def test_token_saving(self, panstore, access_token):
@@ -132,7 +129,7 @@ class TestClass(object):
         if not INDEXING_ENABLED:
             pytest.skip("Indexing needs to be enabled to test this")
 
-        from pantalaimon.index import Index, IndexStore
+        from pantalaimon.index import IndexStore
 
         loop = asyncio.get_event_loop()
 

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -27,7 +27,7 @@ class TestClass(object):
                 "type": "m.room.message",
                 "unsigned": {"age": 43289803095},
                 "user_id": "@example2:localhost",
-                "age": 43289803095
+                "age": 43289803095,
             }
         )
 
@@ -43,39 +43,41 @@ class TestClass(object):
                 "type": "m.room.message",
                 "unsigned": {"age": 43289803095},
                 "user_id": "@example2:localhost",
-                "age": 43289803095
+                "age": 43289803095,
             }
         )
 
     @property
     def encrypted_media_event(self):
-        return RoomEncryptedMedia.from_dict({
-            "room_id": "!testroom:localhost",
-            "event_id": "$15163622445EBvZK:localhost",
-            "origin_server_ts": 1516362244030,
-            "sender": "@example2:localhost",
-            "type": "m.room.message",
-            "content": {
-                "body": "orange_cat.jpg",
-                "msgtype": "m.image",
-                "file": {
-                    "v": "v2",
-                    "key": {
-                        "alg": "A256CTR",
-                        "ext": True,
-                        "k": "yx0QvkgYlasdWEsdalkejaHBzCkKEBAp3tB7dGtWgrs",
-                        "key_ops": ["encrypt", "decrypt"],
-                        "kty": "oct"
+        return RoomEncryptedMedia.from_dict(
+            {
+                "room_id": "!testroom:localhost",
+                "event_id": "$15163622445EBvZK:localhost",
+                "origin_server_ts": 1516362244030,
+                "sender": "@example2:localhost",
+                "type": "m.room.message",
+                "content": {
+                    "body": "orange_cat.jpg",
+                    "msgtype": "m.image",
+                    "file": {
+                        "v": "v2",
+                        "key": {
+                            "alg": "A256CTR",
+                            "ext": True,
+                            "k": "yx0QvkgYlasdWEsdalkejaHBzCkKEBAp3tB7dGtWgrs",
+                            "key_ops": ["encrypt", "decrypt"],
+                            "kty": "oct",
+                        },
+                        "iv": "0pglXX7fspIBBBBAEERLFd",
+                        "hashes": {
+                            "sha256": "eXRDFvh+aXsQRj8a+5ZVVWUQ9Y6u9DYiz4tq1NvbLu8"
+                        },
+                        "url": "mxc://localhost/maDtasSiPFjROFMnlwxIhhyW",
+                        "mimetype": "image/jpeg",
                     },
-                    "iv": "0pglXX7fspIBBBBAEERLFd",
-                    "hashes": {
-                        "sha256": "eXRDFvh+aXsQRj8a+5ZVVWUQ9Y6u9DYiz4tq1NvbLu8"
-                    },
-                    "url": "mxc://localhost/maDtasSiPFjROFMnlwxIhhyW",
-                    "mimetype": "image/jpeg"
-                }
+                },
             }
-        })
+        )
 
     def test_account_loading(self, panstore):
         accounts = panstore.load_all_users()
@@ -131,6 +133,7 @@ class TestClass(object):
             pytest.skip("Indexing needs to be enabled to test this")
 
         from pantalaimon.index import Index, IndexStore
+
         loop = asyncio.get_event_loop()
 
         store = IndexStore("example", tempdir)
@@ -148,8 +151,10 @@ class TestClass(object):
         assert len(result["results"]) == 1
         assert result["count"] == 1
         assert result["results"][0]["result"] == self.test_event.source
-        assert (result["results"][0]["context"]["events_after"][0]
-                == self.another_event.source)
+        assert (
+            result["results"][0]["context"]["events_after"][0]
+            == self.another_event.source
+        )
 
     def test_media_storage(self, panstore):
         server_name = "test"


### PR DESCRIPTION
This PR just does a simple reformat with `ruff` and fixes linting errors. Not exhaustive by any means. Will probably go through and look at variable names and whatnot and touch them up if needed.