### PR TITLE
chore: change from appdirs to platformdirs

### DIFF
--- a/pantalaimon/main.py
+++ b/pantalaimon/main.py
@@ -22,7 +22,7 @@ import keyring
 import logbook
 import nio
 from aiohttp import web
-from appdirs import user_config_dir, user_data_dir
+from platformdirs import user_config_dir, user_data_dir
 from logbook import StderrHandler
 
 from pantalaimon.config import PanConfig, PanConfigError, parse_log_level

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "attrs >= 19.3.0",
         "aiohttp >= 3.6, < 4.0",
-        "appdirs >= 1.4.4",
+        "platformdirs >= 4.3.6",
         "click >= 7.1.2",
         "keyring >= 21.2.1",
         "logbook >= 1.5.3",


### PR DESCRIPTION
These have the same interface since platformdirs is just a fork of appdirs so luckily this was as easy and changing the dependency name.