### PR TITLE
Issue #138: Using shlex.split instead str.split

### DIFF
--- a/pantalaimon/panctl.py
+++ b/pantalaimon/panctl.py
@@ -20,6 +20,7 @@ import sys
 from collections import defaultdict
 from itertools import zip_longest
 from typing import List
+from shlex import split
 
 import attr
 import click
@@ -589,7 +590,7 @@ class PanCtl:
             parser = PanctlParser(self.commands)
 
             try:
-                args = parser.parse_args(result.split())
+                args = parser.parse_args(split(result))
             except ParseError:
                 continue
 

--- a/pantalaimon/panctl.py
+++ b/pantalaimon/panctl.py
@@ -590,7 +590,7 @@ class PanCtl:
             parser = PanctlParser(self.commands)
 
             try:
-                args = parser.parse_args(split(result))
+                args = parser.parse_args(split(result, posix=False))
             except ParseError:
                 continue
 


### PR DESCRIPTION
I have used the  shlex.split function which correctly handles quoted strings, ensuring that the entire passphrase is treated as a single argument.