### PR TITLE
chore: Fix failing tests by removing unused fixture

### DIFF
--- a/tests/pan_client_test.py
+++ b/tests/pan_client_test.py
@@ -25,7 +25,7 @@ ALICE_ID = "@alice:example.org"
 
 
 @pytest.fixture
-async def client(tmpdir, loop):
+async def client(tmpdir):
     store = PanStore(tmpdir)
     queue = janus.Queue()
     conf = ServerConfig("example", "https://example.org")
@@ -371,7 +371,7 @@ class TestClass(object):
 
         await client.loop_stop()
 
-    async def test_history_fetching_tasks(self, client, aioresponse, loop):
+    async def test_history_fetching_tasks(self, client, aioresponse):
         if not INDEXING_ENABLED:
             pytest.skip("Indexing needs to be enabled to test this")
 
@@ -447,7 +447,7 @@ class TestClass(object):
 
         await client.loop_stop()
 
-    async def test_history_fetching_resume(self, client, aioresponse, loop):
+    async def test_history_fetching_resume(self, client, aioresponse):
         if not INDEXING_ENABLED:
             pytest.skip("Indexing needs to be enabled to test this")
 


### PR DESCRIPTION
This fixes the tests by removing an used fixture (`loop`) which also didn't exist. Makes me realize tests should probably be running in the CI. I am now having a bit more time to work on this now that the move has finished and work has settled down a bit. Fixes the last issue with #183 .